### PR TITLE
chore: bump UBI9 to 9.6-1758184894 from 9.5-1744101466

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi:9.5-1744101466
+FROM registry.access.redhat.com/ubi9/ubi:9.6-1758184894
 
 LABEL description="This tool is called comp2..."
 LABEL io.k8s.description="This tool..."


### PR DESCRIPTION
Update the collector's base to the newest image

Slack: https://redhat-internal.slack.com/archives/C031USXS2FJ/p1758617403648359
CVEs: https://catalog.redhat.com/en/software/containers/ubi9/618326f8c0d15aff4912fe0b?image=67f5070ae1cf197c561ff007&architecture=amd64#security