### PR TITLE
chore: use `latest` for base image in Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi:9.5-1744101466
+FROM registry.access.redhat.com/ubi9/ubi:latest
 
 LABEL description="This tool is called comp2..."
 LABEL io.k8s.description="This tool..."


### PR DESCRIPTION
Updating the base UBI image to use the latest tag so that the verify-conforma task will not fail.