### PR TITLE
chore: use `latest` for base image in Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi:9.6-1747219013
+FROM registry.access.redhat.com/ubi9/ubi:latest
 
 LABEL \
   name="releng-test-product" \


### PR DESCRIPTION
Updating the base UBI image to use the latest tag so that the verify-conforma task will not fail.