### PR TITLE
chore: use `latest` for base image in Dockerfiles

### DIFF
--- a/catalog.Dockerfile
+++ b/catalog.Dockerfile
@@ -1,6 +1,6 @@
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM registry.redhat.io/openshift4/ose-operator-registry:v4.13
+FROM registry.redhat.io/openshift4/ose-operator-registry:latest
 
 # Test disabled network access
 #RUN if curl -IsS www.google.com; then echo "ERROR: network access detected!"; exit 1; fi


### PR DESCRIPTION
Updating the base image to use the latest tag so that the verify-conforma task will not fail.
